### PR TITLE
CMC-110 simplify dead links checker jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,17 +50,13 @@ jobs:
       - image: circleci/python:3.5.3
     working_directory: ~/directory-periodical-tests
     steps:
-      - restore_cache:
-          keys:
-            - cached-repo-{{ .Revision }}
-      - restore_cache:
-          keys:
-            - dead-links-dependencies-cache-{{ .Revision }}
+      - checkout
       - run:
           name: Check for dead links
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install -r requirements_dead_links.txt
             TEST_ENV=DEV make dead_links_check
 
   check_for_dead_links_on_stage:
@@ -68,17 +64,13 @@ jobs:
       - image: circleci/python:3.5.3
     working_directory: ~/directory-periodical-tests
     steps:
-      - restore_cache:
-          keys:
-            - cached-repo-{{ .Revision }}
-      - restore_cache:
-          keys:
-            - dead-links-dependencies-cache-{{ .Revision }}
+      - checkout
       - run:
           name: Check for dead links
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install -r requirements_dead_links.txt
             TEST_ENV=STAGE make dead_links_check
 
   check_for_dead_links_on_prod:
@@ -86,17 +78,13 @@ jobs:
       - image: circleci/python:3.5.3
     working_directory: ~/directory-periodical-tests
     steps:
-      - restore_cache:
-          keys:
-            - cached-repo-{{ .Revision }}
-      - restore_cache:
-          keys:
-            - dead-links-dependencies-cache-{{ .Revision }}
+      - checkout
       - run:
           name: Check for dead links
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install -r requirements_dead_links.txt
             TEST_ENV=PROD make dead_links_check
 
 workflows:
@@ -120,13 +108,7 @@ workflows:
           branches:
             only: master
     jobs:
-      - checkout_code
-      - dead_links_dependencies:
-          requires:
-            - checkout_code
-      - check_for_dead_links_on_dev:
-          requires:
-            - dead_links_dependencies
+      - check_for_dead_links_on_dev
 
   stage_check_for_dead_links:
     triggers:
@@ -136,13 +118,7 @@ workflows:
           branches:
             only: master
     jobs:
-      - checkout_code
-      - dead_links_dependencies:
-          requires:
-            - checkout_code
-      - check_for_dead_links_on_stage:
-          requires:
-            - dead_links_dependencies
+      - check_for_dead_links_on_stage
 
   prod_check_for_dead_links:
     triggers:
@@ -152,11 +128,5 @@ workflows:
           branches:
             only: master
     jobs:
-      - checkout_code
-      - dead_links_dependencies:
-          requires:
-            - checkout_code
-      - check_for_dead_links_on_prod:
-          requires:
-            - dead_links_dependencies
+      - check_for_dead_links_on_prod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,6 @@
 version: 2.0
 
 jobs:
-  checkout_code:
-    docker:
-      - image: circleci/python:3.5.3
-    working_directory: ~/directory-periodical-tests
-    steps:
-      - checkout
-      - save_cache:
-          key: cached-repo-{{ .Revision }}
-          paths:
-            - ~/directory-periodical-tests
 
   refresh_geckoboard:
     docker:
@@ -25,25 +15,6 @@ jobs:
             . venv/bin/activate
             pip install -r requirements_geckoboard_updater.txt
             python geckoboard_updater/geckoboard_updater.py
-
-  dead_links_dependencies:
-    docker:
-      - image: circleci/python:3.5.3
-    working_directory: ~/directory-periodical-tests
-    steps:
-      - restore_cache:
-          keys:
-            - cached-repo-{{ .Revision }}
-      - run:
-          name: Create virtualenv and install dependencies
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -r requirements_dead_links.txt
-      - save_cache:
-          key: dead-links-dependencies-cache-{{ .Revision }}
-          paths:
-            - ~/directory-periodical-tests/venv
 
   check_for_dead_links_on_dev:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,107 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+venv/
+.env/
+.venv/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+#Ipython Notebook
+.ipynb_checkpoints
+
+# No need to track the dev db
+db.sqlite3
+
+# PyCharm
+.idea
+
+.direnv/
+
+# OSX
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Docker
+.env
+.env_*
+.env-postgres
+
+# NodeJS (nodeenv)
+package-lock.json
+node_modules/


### PR DESCRIPTION
In order to reduce the number of CIrcleCI jobs and simplify the structure of circleci config each job will  checkout code & install requirements separately (the performance hit is around 20 seconds per build)